### PR TITLE
get HTTP method name using reflection

### DIFF
--- a/core-app/src/main/java/volley/core/network/CoreBaseRequest.java
+++ b/core-app/src/main/java/volley/core/network/CoreBaseRequest.java
@@ -4,6 +4,7 @@ import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 public abstract class CoreBaseRequest<T> {
@@ -18,6 +19,22 @@ public abstract class CoreBaseRequest<T> {
      * @return integer value of Http Method
      */
     protected abstract int httpMethod();
+
+    /**
+     * @param methodCode integer value of HTTP Methods
+     * @return String value of HTTP Methods defined in {@link com.android.volley.Request.Method}
+     */
+    public static String getMethodName(int methodCode) throws IllegalAccessException {
+        Field[] fields = Request.Method.class.getDeclaredFields();
+
+        for (Field field : fields) {
+            if (methodCode == field.getInt(null)) {
+                return field.getName();
+            }
+        }
+
+        return null;
+    }
 
     /**
      * @return the url path that will be concatenated


### PR DESCRIPTION
We can get the name of HTTP method using java reflection. This way we are not tied to the values given to the member fields.
