### PR TITLE
null response class handling is added

### DIFF
--- a/core-app/src/main/java/volley/core/network/CoreGsonRequest.java
+++ b/core-app/src/main/java/volley/core/network/CoreGsonRequest.java
@@ -53,6 +53,7 @@ public class CoreGsonRequest<T> extends Request<T> {
 
     @Override
     protected Response<T> parseNetworkResponse(NetworkResponse response) {
+        if (mClazz == null) return Response.success(null, null);
         try {
             String json = new String(
                     response.data, HttpHeaderParser.parseCharset(response.headers));


### PR DESCRIPTION
In case of there is no response returning back to volley, response class can be set as null. In which case it still returns success (it was returning ParseError before) and client can set it's own logic there.
