### PR TITLE
Add content type method to core requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ To-do
 ---
 * tests
 * gzip support
+* support for content-types other than application/json
 
 License
 ---

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -18,7 +18,6 @@ package io.zeplin.rally.network;
 import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
-import com.google.gson.Gson;
 
 import java.util.Map;
 
@@ -106,24 +105,13 @@ public abstract class CoreBaseRequest<T> {
     }
 
     /**
-     * Can be rented for advanced usages
-     *
-     * @return {@link com.google.gson.Gson object}
-     */
-    protected Gson gson() {
-        return new Gson();
-    }
-
-    /**
      * @return new built of Request class
      */
     public Request<T> create() {
         return new CoreGsonRequest<T>(
-                gson(),
                 httpMethod(),
                 requestUrl(),
                 responseClass(),
-                contentType(),
                 getHeaders(),
                 successListener(),
                 errorListener(),

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -1,18 +1,19 @@
 /*
-* Copyright (C) 2014 Zeplin
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (C) 2014 Zeplin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.zeplin.rally.network;
 
 import com.android.volley.Request;
@@ -48,11 +49,6 @@ public abstract class CoreBaseRequest<T> {
      * @return body of the action
      */
     protected abstract String body();
-
-    /**
-     * @return content type of the body
-     */
-    protected abstract String contentType();
 
     /**
      * @return headers, unless any authorization is needed

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -51,6 +51,11 @@ public abstract class CoreBaseRequest<T> {
     protected abstract String body();
 
     /**
+     * @return content type of the body
+     */
+    protected abstract String contentType();
+
+    /**
      * @return headers, unless any authorization is needed
      */
     protected abstract Map<String, String> getHeaders();
@@ -118,6 +123,7 @@ public abstract class CoreBaseRequest<T> {
                 httpMethod(),
                 requestUrl(),
                 responseClass(),
+                contentType(),
                 getHeaders(),
                 successListener(),
                 errorListener(),

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -34,6 +34,7 @@ public class CoreGsonRequest<T> extends Request<T> {
 
     private final Gson mGson;
     private final Class<T> mClazz;
+    private final String mContentType;
     private final Map<String, String> mHeaders;
     private final Response.Listener<T> mListener;
     private final String mBody;
@@ -44,16 +45,24 @@ public class CoreGsonRequest<T> extends Request<T> {
      * @param method HTTP method that will be used
      * @param url URL of the request to make
      * @param clazz Relevant class object, for Gson's reflection
+     * @param contentType content type of the body
      * @param headers Map of request mHeaders
      */
-    public CoreGsonRequest(Gson gson, int method, String url, Class<T> clazz, Map<String, String> headers,
-                       Response.Listener<T> listener, Response.ErrorListener errorListener, String body) {
+    public CoreGsonRequest(Gson gson, int method, String url, Class<T> clazz, String contentType,
+                           Map<String, String> headers, Response.Listener<T> listener,
+                           Response.ErrorListener errorListener, String body) {
         super(method, url, errorListener);
         mGson = gson;
         mClazz = clazz;
+        mContentType = contentType;
         mHeaders = headers;
         mListener = listener;
         mBody = body;
+    }
+
+    @Override
+    public String getBodyContentType() {
+        return mContentType;
     }
 
     @Override

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -1,18 +1,19 @@
 /*
-* Copyright (C) 2014 Zeplin
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (C) 2014 Zeplin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.zeplin.rally.network;
 
 import com.android.volley.AuthFailureError;


### PR DESCRIPTION
Volley `Request` class adds its own `Content-Type` header via `getBodyContentType()` method. This leads into duplicate `Content-Type` headers to be sent, if `Content-Type` header is set in the `getHeaders()` method. Therefore `CoreGsonRequest` is now extended from `JsonRequest` which automatically handles many things for us.
