### PR TITLE
Add ability to specify naming strategy for gson

### DIFF
--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -56,6 +56,8 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
         super(method, url, body, listener, errorListener);
         mClazz = clazz;
         mHeaders = headers;
+
+        mGson = new Gson();
     }
 
     @Override

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -22,7 +22,9 @@ import com.android.volley.ParseError;
 import com.android.volley.Response;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.android.volley.toolbox.JsonRequest;
+import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
 import java.io.UnsupportedEncodingException;
@@ -35,6 +37,7 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
 
     private final Class<T> mClazz;
     private final Map<String, String> mHeaders;
+    private Gson mGson;
 
     /**
      * Make a request and return a parsed object from JSON.
@@ -73,11 +76,19 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
             String json = new String(
                     response.data, HttpHeaderParser.parseCharset(response.headers));
             return Response.success(
-                    new Gson().fromJson(json, mClazz), HttpHeaderParser.parseCacheHeaders(response));
+                    mGson.fromJson(json, mClazz), HttpHeaderParser.parseCacheHeaders(response));
         } catch (UnsupportedEncodingException e) {
             return Response.error(new ParseError(e));
         } catch (JsonSyntaxException e) {
             return Response.error(new ParseError(e));
         }
+    }
+
+    public CoreGsonRequest withFieldNamingStrategy(FieldNamingStrategy fieldNamingStrategy) {
+        mGson = new GsonBuilder()
+                .setFieldNamingStrategy(fieldNamingStrategy)
+                .create();
+
+        return this;
     }
 }

--- a/rally-lib/src/main/java/io/zeplin/rally/toolbox/CoreVolleyUtil.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/toolbox/CoreVolleyUtil.java
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package io.zeplin.rally.utils;
+package io.zeplin.rally.toolbox;
 
 import com.android.volley.Request;
 

--- a/rally-lib/src/main/java/io/zeplin/rally/toolbox/MFieldNamingStrategy.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/toolbox/MFieldNamingStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014 Zeplin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.zeplin.rally.toolbox;
+
+import com.google.gson.FieldNamingStrategy;
+
+import java.lang.reflect.Field;
+
+public class MFieldNamingStrategy implements FieldNamingStrategy {
+
+    /**
+     * Field member prefix, if any exists
+     */
+    private final String FIELD_NAME_PREFIX = "m";
+
+    @Override
+    public String translateName(Field field) {
+        String fieldName = field.getName();
+
+        if (fieldName.startsWith(FIELD_NAME_PREFIX) && Character.isUpperCase(fieldName.charAt(1))) {
+            //skip first letter
+            // convert first letter of remaining field name to lowercase
+            fieldName = Character.toLowerCase(fieldName.charAt(1))
+                    + fieldName.substring(2);
+        }
+
+        return fieldName;
+    }
+}


### PR DESCRIPTION
Removing gson method from `CoreBaseRequest` prevents specifying a custom gson field naming strategy. This pull request adds a chainable `withFieldNamingStrategy` method to be called before a `CoreGsonRequest` is created.
