### PR TITLE
Feature/field naming st

### DIFF
--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -19,11 +19,11 @@ package io.zeplin.rally.network;
 import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
+import com.google.gson.FieldNamingStrategy;
 
 import java.util.Map;
 
 public abstract class CoreBaseRequest<T> {
-
     /**
      * @return base url of the server
      */
@@ -104,6 +104,17 @@ public abstract class CoreBaseRequest<T> {
      * @return new built of Request class
      */
     public Request<T> create() {
+        return create(null);
+    }
+
+    /**
+     *
+     * @param fieldNamingStrategy custom field naming strategy,
+     * {@link io.zeplin.rally.toolbox.MFieldNamingStrategy} could be used as default.
+     *
+     * @return new built of Request class
+     */
+    public Request<T> create(FieldNamingStrategy fieldNamingStrategy) {
         return new CoreGsonRequest<T>(
                 httpMethod(),
                 requestUrl(),
@@ -111,7 +122,8 @@ public abstract class CoreBaseRequest<T> {
                 getHeaders(),
                 successListener(),
                 errorListener(),
-                body()
+                body(),
+                fieldNamingStrategy
         );
     }
 }

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -104,14 +104,23 @@ public abstract class CoreBaseRequest<T> {
      * @return new built of Request class
      */
     public Request<T> create() {
-        return create(null);
+        return new CoreGsonRequest<T>(
+                httpMethod(),
+                requestUrl(),
+                responseClass(),
+                getHeaders(),
+                successListener(),
+                errorListener(),
+                body()
+        );
     }
 
     /**
+     * Use {@link io.zeplin.rally.toolbox.MFieldNamingStrategy} to have an easier implementation and
+     * follow the field naming conventions:
+     * https://source.android.com/source/code-style.html#follow-field-naming-conventions
      *
-     * @param fieldNamingStrategy custom field naming strategy,
-     * {@link io.zeplin.rally.toolbox.MFieldNamingStrategy} could be used as default.
-     *
+     * @param fieldNamingStrategy custom field naming strategy.
      * @return new built of Request class
      */
     public Request<T> create(FieldNamingStrategy fieldNamingStrategy) {

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -57,13 +57,17 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
         mClazz = clazz;
         mHeaders = headers;
 
-        GsonBuilder gsonBuilder = new GsonBuilder();
+        mGson = new GsonBuilder().setFieldNamingStrategy(fieldNamingStrategy).create();
+    }
 
-        if (fieldNamingStrategy != null) {
-            gsonBuilder.setFieldNamingStrategy(fieldNamingStrategy);
-        }
+    public CoreGsonRequest(int method, String url, Class<T> clazz, Map<String, String> headers,
+                           Response.Listener<T> listener, Response.ErrorListener errorListener,
+                           String body) {
+        super(method, url, body, listener, errorListener);
+        mClazz = clazz;
+        mHeaders = headers;
 
-        mGson = gsonBuilder.create();
+        mGson = new Gson();
     }
 
     @Override

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -52,12 +52,18 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
      */
     public CoreGsonRequest(int method, String url, Class<T> clazz, Map<String, String> headers,
                            Response.Listener<T> listener, Response.ErrorListener errorListener,
-                           String body) {
+                           String body, FieldNamingStrategy fieldNamingStrategy) {
         super(method, url, body, listener, errorListener);
         mClazz = clazz;
         mHeaders = headers;
 
-        mGson = new Gson();
+        GsonBuilder gsonBuilder = new GsonBuilder();
+
+        if (fieldNamingStrategy != null) {
+            gsonBuilder.setFieldNamingStrategy(fieldNamingStrategy);
+        }
+
+        mGson = gsonBuilder.create();
     }
 
     @Override
@@ -84,13 +90,5 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
         } catch (JsonSyntaxException e) {
             return Response.error(new ParseError(e));
         }
-    }
-
-    public CoreGsonRequest withFieldNamingStrategy(FieldNamingStrategy fieldNamingStrategy) {
-        mGson = new GsonBuilder()
-                .setFieldNamingStrategy(fieldNamingStrategy)
-                .create();
-
-        return this;
     }
 }

--- a/rally-lib/src/main/java/io/zeplin/rally/toolbox/MFieldNamingStrategy.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/toolbox/MFieldNamingStrategy.java
@@ -20,6 +20,17 @@ import com.google.gson.FieldNamingStrategy;
 
 import java.lang.reflect.Field;
 
+/**
+ * Customizes default {@link com.google.gson.FieldNamingStrategy}
+ *
+ * Since {@link com.google.gson.Gson} takes field names as default key
+ * for serialization and deserialization,
+ *
+ * This class simply indicates not to care any field name prefixes,
+ * and convert the field name to UPPER_CAMEL_CASE
+ *
+ * i.e: mUserId will be converted userId
+ */
 public class MFieldNamingStrategy implements FieldNamingStrategy {
 
     /**

--- a/rally-lib/src/main/java/io/zeplin/rally/toolbox/MFieldNamingStrategy.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/toolbox/MFieldNamingStrategy.java
@@ -21,13 +21,12 @@ import com.google.gson.FieldNamingStrategy;
 import java.lang.reflect.Field;
 
 /**
- * Customizes default {@link com.google.gson.FieldNamingStrategy}
+ * Specifically customization of the default {@link com.google.gson.FieldNamingStrategy}
  *
  * Since {@link com.google.gson.Gson} takes field names as default key
- * for serialization and deserialization,
+ * for serialization and deserialization.
  *
- * This class simply indicates not to care any field name prefixes,
- * and convert the field name to UPPER_CAMEL_CASE
+ * This class simply indicates not to care "m", as a precise field name prefix.
  *
  * i.e: mUserId will be converted userId
  */


### PR DESCRIPTION
default chain method is removed because it's not the base class of BaseRequest. That makes chaining not possible outside from the library.

I've added a parameter inside `create()` method and leave the default as returns `null`
