### PR TITLE
Get response headers

### DIFF
--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -55,7 +55,7 @@ public abstract class CoreBaseRequest<T> {
     /**
      * @return headers, unless any authorization is needed
      */
-    protected abstract Map<String, String> getHeaders();
+    protected abstract Map<String, String> getRequestHeaders();
 
     /**
      * @return response headers retrieved from {@link io.zeplin.rally.network.CoreGsonRequest}
@@ -117,7 +117,7 @@ public abstract class CoreBaseRequest<T> {
                 httpMethod(),
                 requestUrl(),
                 responseClass(),
-                getHeaders(),
+                getRequestHeaders(),
                 successListener(),
                 errorListener(),
                 body()
@@ -139,7 +139,7 @@ public abstract class CoreBaseRequest<T> {
                 httpMethod(),
                 requestUrl(),
                 responseClass(),
-                getHeaders(),
+                getRequestHeaders(),
                 successListener(),
                 errorListener(),
                 body(),

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreBaseRequest.java
@@ -24,6 +24,8 @@ import com.google.gson.FieldNamingStrategy;
 import java.util.Map;
 
 public abstract class CoreBaseRequest<T> {
+    private CoreGsonRequest<T> mCoreGsonRequest;
+
     /**
      * @return base url of the server
      */
@@ -54,6 +56,13 @@ public abstract class CoreBaseRequest<T> {
      * @return headers, unless any authorization is needed
      */
     protected abstract Map<String, String> getHeaders();
+
+    /**
+     * @return response headers retrieved from {@link io.zeplin.rally.network.CoreGsonRequest}
+     */
+    public Map<String, String> getResponseHeaders() {
+        return mCoreGsonRequest.getResponseHeaders();
+    }
 
     /**
      * callback method for network responses
@@ -104,7 +113,7 @@ public abstract class CoreBaseRequest<T> {
      * @return new built of Request class
      */
     public Request<T> create() {
-        return new CoreGsonRequest<T>(
+        mCoreGsonRequest = new CoreGsonRequest<T>(
                 httpMethod(),
                 requestUrl(),
                 responseClass(),
@@ -113,6 +122,8 @@ public abstract class CoreBaseRequest<T> {
                 errorListener(),
                 body()
         );
+
+        return mCoreGsonRequest;
     }
 
     /**
@@ -124,7 +135,7 @@ public abstract class CoreBaseRequest<T> {
      * @return new built of Request class
      */
     public Request<T> create(FieldNamingStrategy fieldNamingStrategy) {
-        return new CoreGsonRequest<T>(
+        mCoreGsonRequest = new CoreGsonRequest<T>(
                 httpMethod(),
                 requestUrl(),
                 responseClass(),
@@ -134,5 +145,7 @@ public abstract class CoreBaseRequest<T> {
                 body(),
                 fieldNamingStrategy
         );
+
+        return mCoreGsonRequest;
     }
 }

--- a/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
+++ b/rally-lib/src/main/java/io/zeplin/rally/network/CoreGsonRequest.java
@@ -37,6 +37,7 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
 
     private final Class<T> mClazz;
     private final Map<String, String> mHeaders;
+    private Map<String, String> mResponseHeaders;
     private Gson mGson;
 
     /**
@@ -81,12 +82,17 @@ public class CoreGsonRequest<T> extends JsonRequest<T> {
         return mHeaders != null ? mHeaders : super.getHeaders();
     }
 
+    public Map<String, String> getResponseHeaders() {
+        return mResponseHeaders;
+    }
+
     @Override
     protected Response<T> parseNetworkResponse(NetworkResponse response) {
         if (mClazz == null) return Response.success(null, null);
         try {
             String json = new String(
                     response.data, HttpHeaderParser.parseCharset(response.headers));
+            mResponseHeaders = response.headers;
             return Response.success(
                     mGson.fromJson(json, mClazz), HttpHeaderParser.parseCacheHeaders(response));
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
Deviced a way to retrieve response headers from individual Request classes. As a result, `getHeaders` method renamed to `getRequestHeaders`.
